### PR TITLE
Add VP8 transparency compatibility fix in webm format.

### DIFF
--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -5,6 +5,7 @@
         "-pix_fmt", ["pix_fmt",["yuv420p","yuva420p"]],
         "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}],
         "-b:v", "0",
+        "-c:v", ["codec", ["libvpx", "libvpx-vp9"]],
         "-vf", "scale=out_color_matrix=bt709",
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"
     ],

--- a/video_formats/webm.json
+++ b/video_formats/webm.json
@@ -4,7 +4,7 @@
         "-n",
         "-pix_fmt", ["pix_fmt",["yuv420p","yuva420p"]],
         "-crf", ["crf","INT", {"default": 20, "min": 0, "max": 100, "step": 1}],
-        "-b:v", "0",
+        "-b:v", ["bitrate", "STRING", {"default": "0"}],
         "-c:v", ["codec", ["libvpx", "libvpx-vp9"]],
         "-vf", "scale=out_color_matrix=bt709",
         "-color_range", "tv", "-colorspace", "bt709", "-color_primaries", "bt709", "-color_trc", "bt709"

--- a/videohelpersuite/nodes.py
+++ b/videohelpersuite/nodes.py
@@ -105,6 +105,13 @@ def apply_format_widgets(format_name, kwargs):
                     default = {"BOOLEAN": False, "INT": 0, "FLOAT": 0, "STRING": ""}[w[1]]
             kwargs[w[0]] = default
             logger.warn(f"Missing input for {w[0][0]} has been set to {default}")
+
+    # VP8 transparency compatibility fix
+    if format_name == "webm" and kwargs.get('codec') == 'libvpx' and kwargs.get('pix_fmt') == 'yuva420p':
+        # VP8 needs auto-alt-ref disabled for transparency support
+        video_format['main_pass'].extend(['-auto-alt-ref', '0'])
+        logger.info("VP8 transparency mode: auto-alt-ref disabled for compatibility")
+
     wit = iterate_format(video_format, False)
     for w in wit:
         while isinstance(w, list):
@@ -681,7 +688,7 @@ class LoadAudioUpload:
         audio_file = folder_paths.get_annotated_filepath(strip_path(kwargs['audio']))
         if audio_file is None or validate_path(audio_file) != True:
             raise Exception("audio_file is not a valid path: " + audio_file)
-        
+
         return (get_audio(audio_file, start_time, duration),)
 
     @classmethod
@@ -885,7 +892,7 @@ class VideoInfo:
 
     def get_video_info(self, video_info):
         keys = ["fps", "frame_count", "duration", "width", "height"]
-        
+
         source_info = []
         loaded_info = []
 
@@ -919,7 +926,7 @@ class VideoInfoSource:
 
     def get_video_info(self, video_info):
         keys = ["fps", "frame_count", "duration", "width", "height"]
-        
+
         source_info = []
 
         for key in keys:
@@ -951,7 +958,7 @@ class VideoInfoLoaded:
 
     def get_video_info(self, video_info):
         keys = ["fps", "frame_count", "duration", "width", "height"]
-        
+
         loaded_info = []
 
         for key in keys:


### PR DESCRIPTION
1. Disable auto-alt-ref for VP8 when using 'yuva420p' pixel format.
2. Clean up whitespace in nodes.py for better readability.

Update webm.json bitrate configuration
1. Change "-b:v" value from "0" to ["bitrate", "STRING", {"default": "0"}]

新增支援webm可以輸出成vp8格式，且包含透明通道。
另外開放webm節點可以自定義bitrate參數。